### PR TITLE
Attendees

### DIFF
--- a/django_ical/feedgenerator.py
+++ b/django_ical/feedgenerator.py
@@ -66,6 +66,7 @@ ITEM_EVENT_FIELD_MAP = (
     ('rdate',               'rdate'),
     ('exdate',              'exdate'),
     ('status',              'status'),
+    ('attendee',            'attendee'),
 )
 
 
@@ -104,7 +105,10 @@ class ICal20Feed(SyndicationFeed):
             event = Event()
             for ifield, efield in ITEM_EVENT_FIELD_MAP:
                 val = item.get(ifield)
-                if val is not None:
+                if isinstance(val, list):
+                    for list_item in val:
+                        event.add(efield, list_item)
+                elif val is not None:
                     event.add(efield, val)
             calendar.add_component(event)
 

--- a/django_ical/feedgenerator.py
+++ b/django_ical/feedgenerator.py
@@ -105,11 +105,12 @@ class ICal20Feed(SyndicationFeed):
             event = Event()
             for ifield, efield in ITEM_EVENT_FIELD_MAP:
                 val = item.get(ifield)
-                if isinstance(val, list):
-                    for list_item in val:
-                        event.add(efield, list_item)
-                elif val is not None:
-                    event.add(efield, val)
+                if val is not None:
+                    if ifield == 'attendee':
+                        for list_item in val:
+                            event.add(efield, list_item)
+                    else:
+                        event.add(efield, val)
             calendar.add_component(event)
 
 DefaultFeed = ICal20Feed

--- a/django_ical/tests/test_feed.py
+++ b/django_ical/tests/test_feed.py
@@ -43,24 +43,24 @@ class TestItemsFeed(ICalFeed):
             'organizer': 'john.doe@example.com',
             'participants': [
                 {
-                    'name': 'Joe Unresponsive',
                     'email': 'joe.unresponsive@example.com',
-                    'participation_status': 'NEEDS-ACTION'
+                    'cn': 'Joe Unresponsive',
+                    'partstat': 'NEEDS-ACTION',
                 },
                 {
-                    'name': 'Jane Attender',
                     'email': 'jane.attender@example.com',
-                    'participation_status': 'ACCEPTED'
+                    'cn': 'Jane Attender',
+                    'partstat': 'ACCEPTED',
                 },
                 {
-                    'name': 'Dan Decliner',
                     'email': 'dan.decliner@example.com',
-                    'participation_status': 'DECLINED'
+                    'cn': 'Dan Decliner',
+                    'partstat': 'DECLINED',
                 },
                 {
-                    'name': 'Mary Maybe',
                     'email': 'mary.maybe@example.com',
-                    'participation_status': 'TENTATIVE'
+                    'cn': 'Mary Maybe',
+                    'partstat': 'TENTATIVE',
                 },
             ],
             'modified': datetime(2012, 5, 2, 10, 0),
@@ -134,21 +134,28 @@ class TestItemsFeed(ICalFeed):
             return organizer
 
     def item_attendee(self, obj):
-        # All calendars support ATTENDEE attribute, however, for SUBSCRIBED calendars
-        #   it appears that Apple calendar (desktop & iOS) displays event attendees, while Google & Outlook do not
-        attendee_list = list()
-        for participant in obj.participants:
-            attendee = icalendar.vCalAddress('MAILTO:%s' % participant.email)
-            attendee.params = {
-                'cn': icalendar.vText(participant.name),
+        """ All calendars support ATTENDEE attribute, however, at this time, Apple calendar (desktop & iOS) and Outlook
+        display event attendees, while Google does not. For SUBSCRIBED calendars it seems that it is not possible to
+        use the default method to respond. As an alternative, you may review adding custom links to your description
+        or setting up something like CalDav with authentication, which can enable the ability for attendees to respond
+        via the default icalendar protocol."""
+        participants = obj.get('participants', None)
+        if participants:
+            attendee_list = list()
+            default_attendee_params = {
                 'cutype': icalendar.vText('INDIVIDUAL'),
                 'role': icalendar.vText('REQ-PARTICIPANT'),
                 'rsvp': icalendar.vText('TRUE'),  # Does not seem to work for subscribed calendars.
-                'partstat': icalendar.vText(participant.participation_status),
             }
-            attendee_list.append(attendee)
-        return attendee_list
-    
+            for participant in participants:
+                attendee = icalendar.vCalAddress('MAILTO:%s' % participant.pop('email'))
+                participant_dic = default_attendee_params.copy()
+                participant_dic.update(participant)
+                for key, val in participant_dic.items():
+                    attendee.params[key] = icalendar.vText(val)
+                attendee_list.append(attendee)
+            return attendee_list
+
 
 class TestFilenameFeed(ICalFeed):
     feed_type = ICal20Feed
@@ -197,18 +204,19 @@ class ICal20FeedTest(TestCase):
         self.assertEquals(calendar.subcomponents[0]['GEO'].to_ical(), "37.386013;-122.082932")
         self.assertEquals(calendar.subcomponents[0]['LAST-MODIFIED'].to_ical(), b'20120502T100000Z')
         self.assertEquals(calendar.subcomponents[0]['ORGANIZER'].to_ical(), b'MAILTO:john.doe@example.com')
-        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][0].to_ical(),
-                          b'ATTENDEE;CN="Joe Unresponsive";CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;RSVP=TRUE;PARTSTAT'
-                          b'=NEEDS-ACTION:MAILTO:joe.unresponsive@example.com')
-        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][1].to_ical(),
-                          b'ATTENDEE;CN="Jane Attender";CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;RSVP=TRUE;PARTSTAT'
-                          b'=ACCEPTED:MAILTO:jane.attender@example.com')
-        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][2].to_ical(),
-                          b'ATTENDEE;CN="Dan Decliner";CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;RSVP=TRUE;PARTSTAT'
-                          b'=DECLINED:MAILTO:dan.decliner@example.com')
-        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][2].to_ical(),
-                          b'ATTENDEE;CN="Mary Maybe";CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;RSVP=TRUE;PARTSTAT'
-                          b'=TENTATIVE:MAILTO:mary.maybe@example.com')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][0].to_ical(), b'MAILTO:joe.unresponsive@example.com')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][0].params.to_ical(),
+                          b'CN="Joe Unresponsive";CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT;'
+                          b'RSVP=TRUE')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][1].to_ical(), b'MAILTO:jane.attender@example.com')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][1].params.to_ical(),
+                          b'CN="Jane Attender";CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;ROLE=REQ-PARTICIPANT;RSVP=TRUE')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][2].to_ical(), b'MAILTO:dan.decliner@example.com')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][2].params.to_ical(),
+                          b'CN="Dan Decliner";CUTYPE=INDIVIDUAL;PARTSTAT=DECLINED;ROLE=REQ-PARTICIPANT;RSVP=TRUE')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][3].to_ical(), b'MAILTO:mary.maybe@example.com')
+        self.assertEquals(calendar.subcomponents[0]['ATTENDEE'][3].params.to_ical(),
+                          b'CN="Mary Maybe";CUTYPE=INDIVIDUAL;PARTSTAT=TENTATIVE;ROLE=REQ-PARTICIPANT;RSVP=TRUE')
         self.assertEquals(calendar.subcomponents[0]['RRULE'][0].to_ical(), b'FREQ=DAILY;BYHOUR=10')
         self.assertEquals(calendar.subcomponents[0]['RRULE'][1].to_ical(), b'FREQ=MONTHLY;BYMONTHDAY=4')
         self.assertEquals(calendar.subcomponents[0]['EXRULE'][0].to_ical(), b'FREQ=MONTHLY;BYMONTHDAY=-4')

--- a/django_ical/views.py
+++ b/django_ical/views.py
@@ -41,6 +41,7 @@ ICAL_EXTRA_FIELDS = [
     'rdate',            # rdate
     'exdate',           # exdate
     'status',           # CONFIRMED|TENTATIVE|CANCELLED
+    'attendee',         # list of attendees
 ]
 
 
@@ -68,6 +69,7 @@ class ICalFeed(Feed):
     :item_start_datetime: DTSTART
     :item_end_datetime: DTEND
     :item_transparency: TRANSP
+    :item_attendee: ATTENDEE
     """
     feed_type = feedgenerator.DefaultFeed
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -208,6 +208,13 @@ Here is a table of all of the fields that django-ical supports.
 |                       |                       | or tests to know how to     |
 |                       |                       | build them.                 |
 +-----------------------+-----------------------+-----------------------------+
+| item_attendee         | `ATTENDEE `_          | The event attendees.        |
+|                       |                       | Expected to be a list of    |
+|                       |                       | vCalAddress objects. See    |
+|                       |                       | `iCalendar`_ documentation  |
+|                       |                       | or tests to know how to     |
+|                       |                       | build them.                 |
++-----------------------+-----------------------+-----------------------------+
 | item_rrule            | `RRULE`_              | The recurrence rule for     |
 |                       |                       | repeating events.           |
 |                       |                       | See `iCalendar`_            |


### PR DESCRIPTION
Enhancement to add attendees to calendar feed per discussion in https://github.com/jazzband/django-ical/issues/30. The format has been validated via icalendar.org.

Currently, attendees and their responses only seem to display as expected within Apple Calendar, did not show when tested in Google Calendar and Outlook Calendar. I believe this is due to how the vendors have decided to protect users from displaying attendees on public calendar feeds for big events...Also, no calendar client tested allows RSVP response to be submitted via default icalendar method for a subscribed calendar.

