### PR TITLE
Changed assertEquals to assertEqual

### DIFF
--- a/django_ical/tests/test_feed.py
+++ b/django_ical/tests/test_feed.py
@@ -196,8 +196,8 @@ class ICal20FeedTest(TestCase):
 
         response = view(request)
         calendar = icalendar.Calendar.from_ical(response.content)
-        self.assertEquals(calendar["X-WR-CALNAME"], "Test Feed")
-        self.assertEquals(calendar["X-WR-CALDESC"], "Test ICal Feed")
+        self.assertEqual(calendar["X-WR-CALNAME"], "Test Feed")
+        self.assertEqual(calendar["X-WR-CALDESC"], "Test ICal Feed")
 
     def test_items(self):
         request = RequestFactory().get("/test/ical")
@@ -206,106 +206,106 @@ class ICal20FeedTest(TestCase):
         response = view(request)
 
         calendar = icalendar.Calendar.from_ical(response.content)
-        self.assertEquals(len(calendar.subcomponents), 2)
+        self.assertEqual(len(calendar.subcomponents), 2)
 
-        self.assertEquals(calendar.subcomponents[0]["SUMMARY"], "Title1")
-        self.assertEquals(calendar.subcomponents[0]["DESCRIPTION"], "Description1")
+        self.assertEqual(calendar.subcomponents[0]["SUMMARY"], "Title1")
+        self.assertEqual(calendar.subcomponents[0]["DESCRIPTION"], "Description1")
         self.assertTrue(calendar.subcomponents[0]["URL"].endswith("/event/1"))
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTSTART"].to_ical(), b"20120501T180000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTEND"].to_ical(), b"20120501T200000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["GEO"].to_ical(), "37.386013;-122.082932"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["LAST-MODIFIED"].to_ical(), b"20120502T100000Z"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ORGANIZER"].to_ical(),
             b"MAILTO:john.doe@example.com",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][0].to_ical(),
             b"MAILTO:joe.unresponsive@example.com",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][0].params.to_ical(),
             b'CN="Joe Unresponsive";CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICIPANT;'
             b"RSVP=TRUE",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][1].to_ical(),
             b"MAILTO:jane.attender@example.com",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][1].params.to_ical(),
             b'CN="Jane Attender";CUTYPE=INDIVIDUAL;PARTSTAT=ACCEPTED;ROLE=REQ-PARTICIPANT;RSVP=TRUE',
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][2].to_ical(),
             b"MAILTO:dan.decliner@example.com",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][2].params.to_ical(),
             b'CN="Dan Decliner";CUTYPE=INDIVIDUAL;PARTSTAT=DECLINED;ROLE=REQ-PARTICIPANT;RSVP=TRUE',
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][3].to_ical(),
             b"MAILTO:mary.maybe@example.com",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["ATTENDEE"][3].params.to_ical(),
             b'CN="Mary Maybe";CUTYPE=INDIVIDUAL;PARTSTAT=TENTATIVE;ROLE=REQ-PARTICIPANT;RSVP=TRUE',
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["RRULE"][0].to_ical(), b"FREQ=DAILY;BYHOUR=10"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["RRULE"][1].to_ical(),
             b"FREQ=MONTHLY;BYMONTHDAY=4",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["EXRULE"][0].to_ical(),
             b"FREQ=MONTHLY;BYMONTHDAY=-4",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["EXRULE"][1].to_ical(), b"FREQ=MONTHLY;BYDAY=+3TU"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["RDATE"].to_ical(), b"19990902,19980101"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["EXDATE"].to_ical(), b"19990801,19980201"
         )
 
-        self.assertEquals(calendar.subcomponents[1]["SUMMARY"], "Title2")
-        self.assertEquals(calendar.subcomponents[1]["DESCRIPTION"], "Description2")
+        self.assertEqual(calendar.subcomponents[1]["SUMMARY"], "Title2")
+        self.assertEqual(calendar.subcomponents[1]["DESCRIPTION"], "Description2")
         self.assertTrue(calendar.subcomponents[1]["URL"].endswith("/event/2"))
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTSTART"].to_ical(), b"20120506T180000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTEND"].to_ical(), b"20120506T200000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["RRULE"].to_ical(),
             b"FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["EXRULE"].to_ical(), b"FREQ=MONTHLY;BYDAY=-3TU"
         )
-        self.assertEquals(calendar.subcomponents[1]["RDATE"].to_ical(), b"19970902")
-        self.assertEquals(calendar.subcomponents[1]["EXDATE"].to_ical(), b"19970801")
-        self.assertEquals(
+        self.assertEqual(calendar.subcomponents[1]["RDATE"].to_ical(), b"19970902")
+        self.assertEqual(calendar.subcomponents[1]["EXDATE"].to_ical(), b"19970801")
+        self.assertEqual(
             calendar.subcomponents[1]["GEO"].to_ical(), "37.386013;-122.082932"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["LAST-MODIFIED"].to_ical(), b"20120507T100000Z"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["ORGANIZER"].to_ical(),
             b"MAILTO:john.doe@example.com",
         )
@@ -323,7 +323,7 @@ class ICal20FeedTest(TestCase):
 
         response = view(request)
         calendar = icalendar.Calendar.from_ical(response.content)
-        self.assertEquals(calendar["X-WR-TIMEZONE"], "Asia/Tokyo")
+        self.assertEqual(calendar["X-WR-TIMEZONE"], "Asia/Tokyo")
 
     def test_timezone(self):
         tokyo = pytz.timezone("Asia/Tokyo")
@@ -365,33 +365,33 @@ class ICal20FeedTest(TestCase):
 
         response = view(request)
         calendar = icalendar.Calendar.from_ical(response.content)
-        self.assertEquals(len(calendar.subcomponents), 2)
+        self.assertEqual(len(calendar.subcomponents), 2)
 
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTSTART"].to_ical(), b"20120501T180000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTSTART"].params["TZID"], "Asia/Tokyo"
         )
 
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTEND"].to_ical(), b"20120501T200000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[0]["DTEND"].params["TZID"], "Asia/Tokyo"
         )
 
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTSTART"].to_ical(), b"20120506T180000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTSTART"].params["TZID"], "US/Eastern"
         )
 
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTEND"].to_ical(), b"20120506T200000"
         )
-        self.assertEquals(
+        self.assertEqual(
             calendar.subcomponents[1]["DTEND"].params["TZID"], "US/Eastern"
         )
 


### PR DESCRIPTION
`assertEquals` is deprecated in favor of `assertEqual`