### PR TITLE
Add support for VALARM option.

### DIFF
--- a/django_ical/feedgenerator.py
+++ b/django_ical/feedgenerator.py
@@ -67,6 +67,7 @@ ITEM_EVENT_FIELD_MAP = (
     ("exdate", "exdate"),
     ("status", "status"),
     ("attendee", "attendee"),
+    ("valarm", None),
 )
 
 
@@ -110,6 +111,9 @@ class ICal20Feed(SyndicationFeed):
                     if ifield == "attendee":
                         for list_item in val:
                             event.add(efield, list_item)
+                    elif ifield == "valarm":
+                        for list_item in val:
+                            event.add_component(list_item)
                     else:
                         event.add(efield, val)
             calendar.add_component(event)

--- a/django_ical/views.py
+++ b/django_ical/views.py
@@ -36,6 +36,7 @@ ICAL_EXTRA_FIELDS = [
     "exdate",  # exdate
     "status",  # CONFIRMED|TENTATIVE|CANCELLED
     "attendee",  # list of attendees
+    "valarm",  # list of icalendar.Alarm objects
 ]
 
 
@@ -64,6 +65,7 @@ class ICalFeed(Feed):
     :item_end_datetime: DTEND
     :item_transparency: TRANSP
     :item_attendee: ATTENDEE
+    :item_valarm: VALARM
     """
 
     feed_type = feedgenerator.DefaultFeed

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -234,6 +234,12 @@ Here is a table of all of the fields that django-ical supports.
 |                       |                       | documentation or tests to   |
 |                       |                       | know how to build them.     |
 +-----------------------+-----------------------+-----------------------------+
+| item_valarm           | `VALARM`_             | Alarms for the event, must  |
+|                       |                       | be a list of Alarm objects. |
+|                       |                       | See `iCalendar`_            |
+|                       |                       | documentation or tests to   |
+|                       |                       | know how to build them.     |
++-----------------------+-----------------------+-----------------------------+
 | item_status           | `STATUS`_             | The status of an event.     |
 |                       |                       | Can be CONFIRMED, CANCELLED |
 |                       |                       | or TENTATIVE.               |
@@ -278,6 +284,7 @@ See: `The syndication feed framework: Specifying the type of feed <https://docs.
 .. _RDATE: https://www.kanzaki.com/docs/ical/rdate.html
 .. _EXDATE: https://www.kanzaki.com/docs/ical/exdate.html
 .. _STATUS: https://www.kanzaki.com/docs/ical/status.html
+.. _VALARM: https://www.kanzaki.com/docs/ical/valarm.html
 .. _X-WR-CALNAME: http://en.wikipedia.org/wiki/ICalendar#Calendar_extensions
 .. _X-WR-CALDESC: http://en.wikipedia.org/wiki/ICalendar#Calendar_extensions
 .. _X-WR-TIMEZONE: http://en.wikipedia.org/wiki/ICalendar#Calendar_extensions

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -140,6 +140,26 @@ the file name to include the id of the object returned by `get_object()`.
 
         # ...
 
+
+Alarms
+------
+
+Alarms must be `icalendar.Alarm` objects, a list is expected as the return value for
+`item_valarm`.
+
+.. code-block:: python
+
+    from icalendar import Alarm
+    from datetime import timedelta
+    
+    def item_valarm(self, item):
+        valarm = Alarm()
+        valarm.add('action', 'display')
+        valarm.add('description', 'Your message text')
+        valarm.add('trigger', timedelta(days=-1))
+        return [valarm]
+
+
 Property Reference and Extensions
 ---------------------------------
 


### PR DESCRIPTION
Add the possibility to add VALARM subcomponents to calendar entries.

The VALARM component must be constructed directly using the `icalendar.Alarm` class, this is just a minimal wrapper to be able to add it to events.

Closes #46 