### PR TITLE
Add Django 4.2 to the build & declare official support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,18 +10,12 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8']
-        django-version: ['3.2', '4.0', '4.1']
+        django-version: ['3.2', '4.0', '4.1', '4.2']
         include:
           # Tox configuration for QA environment
           - python-version: '3.10'
             django-version: 'qa'
           # Django main
-          - python-version: '3.8'
-            django-version: 'main'
-            experimental: true
-          - python-version: '3.9'
-            django-version: 'main'
-            experimental: true
           - python-version: '3.10'
             django-version: 'main'
             experimental: true

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: MIT License",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{38,39,310,py38}-dj32
     py{38,39,310,py38}-dj40
     py{38,39,310,311,py38}-dj41
+    py{38,39,310,311,py38}-dj42
     py{310}-djmain
 
 [gh-actions]
@@ -11,7 +12,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py310
+    3.11: py311
     pypy-3.8: pypy38
 
 [gh-actions:env]
@@ -19,6 +20,7 @@ DJANGO =
     3.2: dj32
     4.0: dj40
     4.1: dj41
+    4.2: dj42
     main: djmain
     qa: djqa
 
@@ -31,6 +33,7 @@ deps =
     dj32: django>=3.1,<3.2
     dj40: django>=4.0,<4.1
     dj41: django>=4.1,<4.2
+    dj42: django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
 commands =
     coverage run setup.py test


### PR DESCRIPTION
Adding Django 4.2 to the build matrix. Pypy tests are failing, but that seems unrelated to this change... Any insights are welcome.